### PR TITLE
fix for popup in specdm

### DIFF
--- a/lua/terrortown/autorun/server/sv_blight_handler.lua
+++ b/lua/terrortown/autorun/server/sv_blight_handler.lua
@@ -86,6 +86,7 @@ hook.Add("TTT2PostPlayerDeath", "BlightKilled", function(ply, _, attacker)
   if GetRoundState() ~= ROUND_ACTIVE then return end
   if not IsValid(ply) or not IsValid(attacker) or not attacker:IsPlayer() then return end
   if ply:GetSubRole() ~= ROLE_BLIGHT then return end
+  if SpecDM and (ply.IsGhost and ply:IsGhost() or (attacker.IsGhost and attacker:IsGhost())) then return end
   attacker:SetNWBool("isBlighted", true)
   attacker.blightTime = CurTime() + GetConVar("ttt2_blt_delay"):GetInt()
   attacker.blightPly = ply:SteamID()


### PR DESCRIPTION
Tested with and without specdm installed on the newest ttt2 version.
This fixes the problem where the blight causes the popup "You feel sick" or "You feel much better" to appear in specdm if he is in specdm.